### PR TITLE
Fix titlebar background color

### DIFF
--- a/buttons.theme.css
+++ b/buttons.theme.css
@@ -8,7 +8,7 @@
 div[class*=withFrame_] {
     height: 34px;
     margin-top: 0px;
-    background-color: var(--bg-base-tertiary);
+    background-color: var(--background-tertiary);
 }
 div[class*=winButton_] {
     position: relative;


### PR DESCRIPTION
I noticed the background color of the titlebar was a little off, so I changed the value of `background-color` from `--bg-base-tertiary` to `--background-tertiary` to make it match the server list.

Screenshot before the change:
![image](https://github.com/user-attachments/assets/732c3240-8e13-4087-9229-179ad51ca517)

After:
![image](https://github.com/user-attachments/assets/459d9114-ce18-446d-b50c-e786c76566a4)

I also made sure it works in light mode.